### PR TITLE
Renamed folder, added languages, removed unnecessary example lines

### DIFF
--- a/assessments/projects/OpenMetrics/self-assessment.md
+++ b/assessments/projects/OpenMetrics/self-assessment.md
@@ -30,20 +30,16 @@ Express Learning course provided by Linux Foundation Training & Certification:
 
 ## Metadata
 
-A table at the top for quick reference information, later used for indexing.
-
 |   |  |
 | -- | -- |
 | Software | https://github.com/OpenObservability/OpenMetrics |
 | Security Provider | No |
-| Languages | GO, HTML,  |
+| Languages | GO-89.1%, HTML-4.9%, Makefile-3.6%, Sass-1.7%, Python-0.3%, Dockerfile-0.3%, Ruby-0.1%  |
 | SBOM | https://github.com/OpenObservability/OpenMetrics/blob/main/src/go.mod |
 | | |
 
 ### Security links
 
-Provide the list of links to existing security documentation for the project. You may
-use the table below as an example:
 | Doc | url |
 | -- | -- |
 | Security file | https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md |


### PR DESCRIPTION
Renamed our project folder to OpenMetrics, added languages used in our project, removed unnecessary example lines in self-assessment.md